### PR TITLE
Simplifying the interface to claiming an NFT from social wallet

### DIFF
--- a/SDK/build.gradle
+++ b/SDK/build.gradle
@@ -70,7 +70,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'fan.vault.sdk'
                 artifactId = 'sdk'
-                version = '1.0.7'
+                version = '1.0.8'
             }
         }
         repositories {

--- a/SDK/src/main/java/fan/vault/sdk/client/VaultBase.kt
+++ b/SDK/src/main/java/fan/vault/sdk/client/VaultBase.kt
@@ -5,16 +5,31 @@ import com.solana.Solana
 import fan.vault.sdk.workers.*
 
 abstract class VaultBase(private val applicationContext: Context) {
-    protected val storageWorker by lazy { StorageWorker(applicationContext) }
+    private val storageWorker by lazy { StorageWorker(applicationContext) }
+    private val solanaWorker by lazy { SolanaWorker() }
     protected val walletWorker by lazy { WalletWorker(storageWorker) }
     protected val proteusAPIWorker by lazy { ProteusAPIWorker.create() }
-    protected val solanaWorker by lazy { SolanaWorker() }
     protected val claimNFTWorker by lazy { ClaimNFTWorker(proteusAPIWorker, solanaWorker) }
 
+    /**
+     * Get public key of user's App Wallet.
+     *
+     * @return Stringified public key of user's App Wallet.
+     */
     fun getAppWalletPublicKey(): String = walletWorker.loadWallet().publicKey.toString()
 
+    /**
+     * Load cached One Time Password from secure storage, if available.
+     *
+     * @return One Time Password cached in secure storage or null if not available.
+     */
     fun getOtp(): String? = storageWorker.loadOtp()
 
+    /**
+     * Cache new One Time Password for use with future requests.
+     *
+     * @param otp One Time Password to cache.
+     */
     fun saveOtp(otp: String) = storageWorker.saveOtp(otp)
 
 }


### PR DESCRIPTION
## Description
Simplifying the interface to claiming an NFT from social wallet.

## Work Completed
- Removes parameter for appWallet as can be generated within the SDK
- Renamed nftAddress to nftMint for better clarity
- Caches new OTP used when claiming
- Adds some header documentation to external interface
- Increments version to 1.0.8

## API Changes
- Removes parameter for appWallet as can be generated within the SDK
- Renamed nftAddress to nftMint for better clarity
- Adds some header documentation to external interface