### PR TITLE
Adds retry mechanism to sign and send transaction step of claiming an NFT from Social Wallet

### DIFF
--- a/SDK/build.gradle
+++ b/SDK/build.gradle
@@ -70,7 +70,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'fan.vault.sdk'
                 artifactId = 'sdk'
-                version = '1.0.8'
+                version = '1.0.9'
             }
         }
         repositories {

--- a/SDK/src/main/java/fan/vault/sdk/client/Vault.kt
+++ b/SDK/src/main/java/fan/vault/sdk/client/Vault.kt
@@ -1,7 +1,6 @@
 package fan.vault.sdk.client
 
 import android.content.Context
-import com.solana.core.Account
 import com.solana.core.PublicKey
 import fan.vault.sdk.models.OneTimePasswordRequest
 
@@ -26,7 +25,7 @@ class Vault(applicationContext: Context) : VaultBase(applicationContext) {
      * @param emailAddress Email address for desired Social Wallet.
      * @return List of claimable NFTs from Social Wallet and their associated metadata.
      */
-    suspend fun listClaimableNftsLinkedTo(emailAddress: String) =
+    suspend fun listClaimableNFTsLinkedTo(emailAddress: String) =
         claimNFTWorker.getClaimableNfts(emailAddress)
 
     /**

--- a/SDK/src/main/java/fan/vault/sdk/client/VaultBase.kt
+++ b/SDK/src/main/java/fan/vault/sdk/client/VaultBase.kt
@@ -32,4 +32,9 @@ abstract class VaultBase(private val applicationContext: Context) {
      */
     fun saveOtp(otp: String) = storageWorker.saveOtp(otp)
 
+    /**
+     * Clear cached One Time Password.
+     */
+    fun clearCachedOtp() = storageWorker.clearOtp()
+
 }

--- a/SDK/src/main/java/fan/vault/sdk/client/VaultRx.kt
+++ b/SDK/src/main/java/fan/vault/sdk/client/VaultRx.kt
@@ -1,7 +1,6 @@
 package fan.vault.sdk.client
 
 import android.content.Context
-import com.solana.core.Account
 import com.solana.core.PublicKey
 import fan.vault.sdk.models.OneTimePasswordRequest
 import io.reactivex.rxjava3.core.Single
@@ -30,7 +29,7 @@ class VaultRx(applicationContext: Context) : VaultBase(applicationContext) {
      * @param emailAddress Email address for desired Social Wallet.
      * @return List of claimable NFTs from Social Wallet and their associated metadata.
      */
-    fun listClaimableNftsLinkedTo(emailAddress: String) =
+    fun listClaimableNFTsLinkedTo(emailAddress: String) =
         rxSingle { claimNFTWorker.getClaimableNfts(emailAddress) }
 
     /**

--- a/SDK/src/main/java/fan/vault/sdk/workers/StorageWorker.kt
+++ b/SDK/src/main/java/fan/vault/sdk/workers/StorageWorker.kt
@@ -56,6 +56,8 @@ class StorageWorker constructor(applicationContext: Context) {
 
     fun loadOtp(): String? = sharedPreferences.getString(VAULT_USER_DEVICE_OTP, null)
 
+    fun clearOtp() = sharedPreferences.edit().remove(VAULT_USER_DEVICE_OTP).apply()
+
     fun clearAllStoredInfo() = sharedPreferences.edit().clear().apply()
 
     companion object {


### PR DESCRIPTION
## Description
Adds retry mechanism to sign and send transaction step of claiming an NFT from Social Wallet

## Work Completed
- Adds retry mechanism to sign and send transaction step of claiming an NFT from Social Wallet
- Adds function to clear cached OTP if the host app needs to do so
- Consistency of function names/capitalisation in external interface

## API Changes
- Made capitalisation of 'NFT' in external interface functions more consistent

## Testing
- Existing unit tests passing