### PR TITLE
Add error management for for incorrect OTP

### DIFF
--- a/SDK/build.gradle
+++ b/SDK/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:4.0.0"
     testImplementation "org.mockito:mockito-inline:4.0.0"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+    testImplementation "com.squareup.retrofit2:retrofit-mock:2.2.0"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 

--- a/SDK/build.gradle
+++ b/SDK/build.gradle
@@ -71,7 +71,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'fan.vault.sdk'
                 artifactId = 'sdk'
-                version = '1.0.11'
+                version = '1.0.12'
             }
         }
         repositories {

--- a/SDK/src/main/java/fan/vault/sdk/models/APIError.kt
+++ b/SDK/src/main/java/fan/vault/sdk/models/APIError.kt
@@ -1,0 +1,3 @@
+package fan.vault.sdk.models
+
+data class APIError(val error: String)

--- a/SDK/src/main/java/fan/vault/sdk/utils/APIUtils.kt
+++ b/SDK/src/main/java/fan/vault/sdk/utils/APIUtils.kt
@@ -1,0 +1,14 @@
+package fan.vault.sdk.utils
+
+class APIUtils {
+    companion object {
+        fun throwError(errorMessage: String) {
+            when (errorMessage) {
+                "Incorrect OTP or Email" -> throw IncorrectOTPOrEmail()
+                else -> throw Exception()
+            }
+        }
+    }
+}
+
+class IncorrectOTPOrEmail : Exception()

--- a/SDK/src/main/java/fan/vault/sdk/utils/APIUtils.kt
+++ b/SDK/src/main/java/fan/vault/sdk/utils/APIUtils.kt
@@ -2,13 +2,13 @@ package fan.vault.sdk.utils
 
 class APIUtils {
     companion object {
-        fun throwError(errorMessage: String) {
-            when (errorMessage) {
-                "Incorrect OTP or Email" -> throw IncorrectOTPOrEmail()
-                else -> throw Exception()
+        fun classifyErrorIfKnown(errorMessage: String): Exception? {
+            return when (errorMessage) {
+                "Incorrect OTP or Email" -> IncorrectOTPOrEmail(errorMessage)
+                else -> null
             }
         }
     }
 }
 
-class IncorrectOTPOrEmail : Exception()
+class IncorrectOTPOrEmail(message: String) : Exception(message)

--- a/SDK/src/main/java/fan/vault/sdk/workers/ClaimNFTWorker.kt
+++ b/SDK/src/main/java/fan/vault/sdk/workers/ClaimNFTWorker.kt
@@ -35,8 +35,8 @@ class ClaimNFTWorker(val proteusAPIWorker: ProteusAPIWorker, val solanaWorker: S
                 }
                 .first()
         } else {
-            APIUtils.throwError(txResponse.errorBody()?.string() ?: "")
-            return null
+            val errorMessage = txResponse.errorBody()?.string() ?: ""
+            throw APIUtils.classifyErrorIfKnown(errorMessage) ?: Error(errorMessage)
         }
     }
 

--- a/SDK/src/main/java/fan/vault/sdk/workers/ClaimNFTWorker.kt
+++ b/SDK/src/main/java/fan/vault/sdk/workers/ClaimNFTWorker.kt
@@ -3,6 +3,7 @@ package fan.vault.sdk.workers
 import com.solana.core.Account
 import com.solana.core.PublicKey
 import fan.vault.sdk.models.NftWithMetadata
+import fan.vault.sdk.utils.APIUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 
@@ -34,7 +35,8 @@ class ClaimNFTWorker(val proteusAPIWorker: ProteusAPIWorker, val solanaWorker: S
                 }
                 .first()
         } else {
-            throw Error(txResponse.errorBody()?.string())
+            APIUtils.throwError(txResponse.errorBody()?.string() ?: "")
+            return null
         }
     }
 

--- a/SDK/src/main/java/fan/vault/sdk/workers/ProteusAPIWorker.kt
+++ b/SDK/src/main/java/fan/vault/sdk/workers/ProteusAPIWorker.kt
@@ -2,8 +2,8 @@ package fan.vault.sdk.workers
 
 import fan.vault.sdk.models.*
 import okhttp3.OkHttpClient
+import retrofit2.Response
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -28,7 +28,7 @@ interface ProteusAPIWorker {
         @Path("appWallet") appWallet: String,
         @Path("mint") mint: String,
         @Path("otp") otp: String
-    ): TransactionResponse
+    ): Response<TransactionResponse>
 
     companion object {
         private const val BASE_URL = "https://v0uusuz5j4.execute-api.us-east-2.amazonaws.com/"
@@ -45,9 +45,9 @@ interface ProteusAPIWorker {
                 .baseUrl(BASE_URL)
                 .client(client)
                 .addConverterFactory(GsonConverterFactory.create())
-                .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
                 .build()
                 .create(ProteusAPIWorker::class.java)
         }
+
     }
 }

--- a/SDK/src/test/java/fan/vault/sdk/workers/ClaimNFTWorkerTest.kt
+++ b/SDK/src/test/java/fan/vault/sdk/workers/ClaimNFTWorkerTest.kt
@@ -7,16 +7,13 @@ import fan.vault.sdk.models.TransactionResponse
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.slot
-import io.reactivex.rxjava3.core.Single
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
+import retrofit2.Response
 
 class ClaimNFTWorkerTest {
     @Before
@@ -59,7 +56,7 @@ class ClaimNFTWorkerTest {
                     otp = otp
                 )
             ).thenReturn(
-                TransactionResponse("AowfOvMIGMKpHdSMkJngzXiF+R1nhZpXl4ead8v9j2KMRNGWxw4ORAEMBxVDHauoPybbYzxE8DxwVkGNSlpHJA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAGDE1NcOheAvyv+bxRcoAAg+MRGtu2bkAm/5wdXQJ8rken1FULStGZ1asG/Yq4nf1D5fRiPugrD4fCDubSMsuHkdIayMAB688AuwbzoF9XnkQFo2FzCNJXzqL54DE6mJ3jcVhQyOsVuOXyU8XVGmOO2ep3vzbZGM4vgpLvjEcAM00J+V3TgVRf23jeOe/lnzkzO6KxIRRsdiBzWWuNQTu8yH/6ZEwlvNmeorQ162ZCz63Oge4CfDiNpiav1AqEyomoh3Fva1OSac1YjEGTGcfA31cfJcQU3+q9HrQZS+lxomSRdvMm5PB133e9DwijLEt6TSX1hyKy/MHeJpT5sgfx0Q6rTKN/L2kwSCbxyvNbI19PNeLYInltDmx6X1AtAMntzsjbHnHIO/C4BzQArccr6sxzJRGosQj9TDQA5uKlJYJ+C3BlsePRfEU4nVJ/awTDzVi4bHMaoP21SbbRvAP4KUYG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqS9th6tOQZlmjaIuFlZG82nyqa3jkyOF4l/umJZJMUYrAQcMAwQFAgABBggJCwsKQgxhNeMOztloLAAAAHE5N3A1TzE3VXRqWUVwRWI4UVd0Y0tXTi9hK0Q4MjI0OFhwOEdDNEFSczg9BgAAADEyMzQ1Ng==")
+                Response.success(TransactionResponse("AowfOvMIGMKpHdSMkJngzXiF+R1nhZpXl4ead8v9j2KMRNGWxw4ORAEMBxVDHauoPybbYzxE8DxwVkGNSlpHJA8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAGDE1NcOheAvyv+bxRcoAAg+MRGtu2bkAm/5wdXQJ8rken1FULStGZ1asG/Yq4nf1D5fRiPugrD4fCDubSMsuHkdIayMAB688AuwbzoF9XnkQFo2FzCNJXzqL54DE6mJ3jcVhQyOsVuOXyU8XVGmOO2ep3vzbZGM4vgpLvjEcAM00J+V3TgVRf23jeOe/lnzkzO6KxIRRsdiBzWWuNQTu8yH/6ZEwlvNmeorQ162ZCz63Oge4CfDiNpiav1AqEyomoh3Fva1OSac1YjEGTGcfA31cfJcQU3+q9HrQZS+lxomSRdvMm5PB133e9DwijLEt6TSX1hyKy/MHeJpT5sgfx0Q6rTKN/L2kwSCbxyvNbI19PNeLYInltDmx6X1AtAMntzsjbHnHIO/C4BzQArccr6sxzJRGosQj9TDQA5uKlJYJ+C3BlsePRfEU4nVJ/awTDzVi4bHMaoP21SbbRvAP4KUYG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqS9th6tOQZlmjaIuFlZG82nyqa3jkyOF4l/umJZJMUYrAQcMAwQFAgABBggJCwsKQgxhNeMOztloLAAAAHE5N3A1TzE3VXRqWUVwRWI4UVd0Y0tXTi9hK0Q4MjI0OFhwOEdDNEFSczg9BgAAADEyMzQ1Ng=="))
             )
 
             runCatching {

--- a/SDK/src/test/java/fan/vault/sdk/workers/ProteusAPIWorkerTest.kt
+++ b/SDK/src/test/java/fan/vault/sdk/workers/ProteusAPIWorkerTest.kt
@@ -1,0 +1,45 @@
+package fan.vault.sdk.workers
+
+import com.google.gson.GsonBuilder
+import fan.vault.sdk.models.APIError
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+
+class ProteusAPIWorkerTest {
+
+    private val gson = GsonBuilder().create()
+
+    @Test
+    fun shouldGetWrongOTPError() {
+        val email = "ant@vault.fan"
+        val appWallet = "CE2yUfCQGUzMi7imdLcGeqnfGBGz2zsmKFtU2d7pTfUC"
+        val mint = "7SQUL7GcLCBvey4KxmUZEdVR5P23VLtVBhebVzfMN5G3"
+        val otp = "fefa5fe4-6551-47a0-82ca-f4c6c7f35"
+
+        runBlocking {
+            val txResp =
+                instance().getSocialToAppWalletClaimTransaction(email, appWallet, mint, otp)
+            val apiError = gson.fromJson(txResp.errorBody()?.string(), APIError::class.java)
+            assertFalse(txResp.isSuccessful)
+            assertEquals("Incorrect OTP or Email", apiError.error)
+        }
+    }
+
+    @Test
+    fun shouldGetCorrectOTPResult() {
+        val email = "ant@vault.fan"
+        val appWallet = "CE2yUfCQGUzMi7imdLcGeqnfGBGz2zsmKFtU2d7pTfUC"
+        val mint = "7SQUL7GcLCBvey4KxmUZEdVR5P23VLtVBhebVzfMN5G3"
+        val otp = "fefa5fe4-6551-47a0-82ca-f4c6c7f35ccc"
+
+        runBlocking {
+            val txResp =
+                instance().getSocialToAppWalletClaimTransaction(email, appWallet, mint, otp)
+            assertTrue(txResp.isSuccessful)
+        }
+    }
+
+    private fun instance() =
+        ProteusAPIWorker.create()
+}


### PR DESCRIPTION
## Description
- It would be useful for the Apps to know if the claim transaction failed due to incorrect data (OTP or email)

## Work Completed
- Change call to claim transaction generation endpoint to be a response that includes the error message from the API. This error message then gets propagated through the SDK to the Apps so they can be clear on it.

## API Changes
- the function `initiateClaimNFTLinkedTo` now throws an appropriate error when the OTP or email is wrong

## Testing
- Unit test to check API response