### PR TITLE
Bug fix - Only save OTP on successful claim

### DIFF
--- a/SDK/build.gradle
+++ b/SDK/build.gradle
@@ -71,7 +71,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'fan.vault.sdk'
                 artifactId = 'sdk'
-                version = '1.0.14'
+                version = '1.0.15'
             }
         }
         repositories {

--- a/SDK/src/main/java/fan/vault/sdk/client/Vault.kt
+++ b/SDK/src/main/java/fan/vault/sdk/client/Vault.kt
@@ -61,13 +61,14 @@ class Vault(applicationContext: Context) : VaultBase(applicationContext) {
         newOtp: String? = null
     ): String? {
         val otp = newOtp ?: getOtp() ?: throw Throwable("OTP cannot be null")
-        newOtp?.let { saveOtp(it) }
         return claimNFTWorker.claim(
             nftMint,
             emailAddress,
             walletWorker.loadWallet(),
             otp
-        )
+        )?.also {
+            saveOtp(otp)
+        }
     }
 
     /**

--- a/SDK/src/main/java/fan/vault/sdk/client/VaultRx.kt
+++ b/SDK/src/main/java/fan/vault/sdk/client/VaultRx.kt
@@ -67,14 +67,15 @@ class VaultRx(applicationContext: Context) : VaultBase(applicationContext) {
         newOtp: String? = null
     ): Single<String> {
         val otp = newOtp ?: getOtp() ?: throw Throwable("OTP cannot be null")
-        newOtp?.let { saveOtp(it) }
         return rxSingle {
             claimNFTWorker.claim(
                 nftMint,
                 emailAddress,
                 walletWorker.loadWallet(),
                 otp
-            ) ?: ""
+            )?.also {
+                saveOtp(otp)
+            } ?: ""
         }
     }
 


### PR DESCRIPTION
## Description
- Only save OTP on successful claim transaction
- Prevents repeating incorrect OTP on subsequent claim attempts

## Work Completed
- Perform saveOtp() function call in also block following claim success

## API Changes
- None